### PR TITLE
updated db and liftopia tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Or install it yourself as:
 ```ruby
 require 'maxminddb/geolite2/city'
 
-MaxMindDB.default_city_db.lookup('8.8.8.8').city.name
-# => "Mountain View"
+MaxMindDB.default_city_db.lookup('74.125.224.72').city.name
+# => "Alameda"
+
+# or, to use the LOW_MEMORY_FILE_READER
+MaxMindDB.default_city_db(MaxMindDB::LOW_MEMORY_FILE_READER).lookup('74.125.224.72').city.name
+# => "Alameda"
 ```
 
 ## Development

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :update_db do
 end
 
 def is_same_db?
-  checksum = `md5sum -b ./lib/maxminddb/geolite2/db/GeoLite2-City.mmdb`.split(' ')[0]
+  checksum = `md5 ./lib/maxminddb/geolite2/db/GeoLite2-City.mmdb`.split(' ').last
   fetch_db_md5_checksum == checksum
 end
 
@@ -55,7 +55,7 @@ def download_db
 end
 
 def db_checksum_valid?(db_path)
-  checksum = `md5sum -b #{db_path}`.split(' ')[0]
+  checksum = `md5 #{db_path}`.split(' ').last
   fetch_db_md5_checksum == checksum
 end
 

--- a/lib/maxminddb/geolite2/city.rb
+++ b/lib/maxminddb/geolite2/city.rb
@@ -2,10 +2,10 @@ require 'maxminddb/geolite2/city/version'
 require 'maxminddb'
 
 module MaxMindDB
-  def MaxMindDB.default_city_db
+  def MaxMindDB.default_city_db(file_reader = nil)
     return @default_city_db if @default_city_db
 
     default_db_path = File.join(File.dirname(__FILE__), 'db', 'GeoLite2-City.mmdb')
-    @default_city_db = MaxMindDB.new(default_db_path)
+    @default_city_db = (file_reader == nil ? MaxMindDB.new(default_db_path) : MaxMindDB.new(default_db_path, file_reader))
   end
 end

--- a/lib/maxminddb/geolite2/city/version.rb
+++ b/lib/maxminddb/geolite2/city/version.rb
@@ -1,7 +1,7 @@
 module MaxMindDB
   module Geolite2
     module City
-      VERSION = "1.6.0"
+      VERSION = "2.0.0" # Was 1.6.0, but for liftopia, we jumped to 2.0.0 to distinguish our forked version
     end
   end
 end

--- a/maxminddb-geolite2-city.gemspec
+++ b/maxminddb-geolite2-city.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "highline", "~> 1.7"
 
-  spec.add_dependency "maxminddb", ">= 0.1.11"
+  spec.add_dependency "maxminddb", ">= 0.1.21"
 end

--- a/spec/maxminddb/geolite2/city_spec.rb
+++ b/spec/maxminddb/geolite2/city_spec.rb
@@ -12,6 +12,6 @@ describe MaxMindDB::Geolite2::City do
   end
 
   it "supports city lookup" do
-    expect(default_db.lookup('8.8.8.8').city.name).to eq("Mountain View")
+    expect(default_db.lookup('74.125.224.72').city.name).to eq("Alameda")
   end
 end


### PR DESCRIPTION
The maxminddb-geolite2-city gem provides a thin wrapper around the maxminddb gem and its main benefit is providing a way to get the maxminddb GeoLite2-City database onto development machines & servers through bundle install, without having that database (which is kind of large) fattening up the git history on our rtopia project. Alternatively, we could have scripts that download the database from somewhere, but this seems like a better way of packaging it and fitting into our dev & deploy workflow.

Unfortunately, the Phybbit version of maxminddb-geolite2-city isn't well maintained (hasn't been updated in 1+ years) and is out of date on both the database and the maxminddb gem. It also doesn't support the low-memory reader syntax that we might decide to use, and the rake tasks for updating the db don't work on the mac.

Since it's such a simple, tiny codebase, I thought it was reasonable to just fork it and maintain our own fork.

Here's what's changed in our version...

- it's updated to use the latest maxminddb gem
- it's updated to use the latest GeoLite2-City database
- initializer now supports the low-memory file reader
- update_db rake task now works on a mac
- I updated the internal version number to 2.0.0 to separate it from the Phybbit

RFC @liftopia/engineering 